### PR TITLE
スポット画像用のモデルを追加

### DIFF
--- a/app/models/periphery.rb
+++ b/app/models/periphery.rb
@@ -1,2 +1,3 @@
 class Periphery < ApplicationRecord
+  belongs_to :spot
 end

--- a/app/models/periphery.rb
+++ b/app/models/periphery.rb
@@ -1,0 +1,2 @@
+class Periphery < ApplicationRecord
+end

--- a/app/models/periphery.rb
+++ b/app/models/periphery.rb
@@ -1,3 +1,5 @@
 class Periphery < ApplicationRecord
   belongs_to :spot
+
+  mount_uploader :sub_visual, SubVisualUploader
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -4,5 +4,7 @@ class Spot < ApplicationRecord
   validates :name, presence: true, length: {maximum: 25}
   validates :main_visual, presence: true
 
+  has_many :peripheries
+
   mount_uploader :main_visual, MainVisualUploader
 end

--- a/app/uploaders/sub_visual_uploader.rb
+++ b/app/uploaders/sub_visual_uploader.rb
@@ -1,0 +1,47 @@
+class SubVisualUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/db/migrate/20200605132725_create_peripheries.rb
+++ b/db/migrate/20200605132725_create_peripheries.rb
@@ -1,0 +1,8 @@
+class CreatePeripheries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :peripheries do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200605132725_create_peripheries.rb
+++ b/db/migrate/20200605132725_create_peripheries.rb
@@ -1,7 +1,8 @@
 class CreatePeripheries < ActiveRecord::Migration[5.2]
   def change
     create_table :peripheries do |t|
-
+      t.string :sub_visual
+      t.references :spot, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_05_130125) do
+ActiveRecord::Schema.define(version: 2020_06_05_132725) do
+
+  create_table "peripheries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "sub_visual"
+    t.bigint "spot_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["spot_id"], name: "index_peripheries_on_spot_id"
+  end
 
   create_table "spots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", limit: 25, null: false
@@ -40,5 +48,6 @@ ActiveRecord::Schema.define(version: 2020_06_05_130125) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "peripheries", "spots"
   add_foreign_key "spots", "users"
 end


### PR DESCRIPTION
# What
スポット登録をする際のメイン画像ではなく、
サブとしての画像の登録・編集をするモデルを追加

# Why
スポットをより伝えやすくするため
画像を見ることで、よりスポットを知れるようにするため